### PR TITLE
Add build requirement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ cat filename | snappy - > compressed_file
 ```
 
 ## Build
+Make sure that the package `libsnappy-dev` (Debian) or `snappy` (Arch) is installed.
 ```
 git clone https://github.com/LevitatingBusinessMan/snappy-cli.git
 cd snappy-cli

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cat filename | snappy - > compressed_file
 ```
 
 ## Build
-Make sure that the package `libsnappy-dev` (Debian) or `snappy` (Arch) is installed.
+Make sure the snappy library and headers are installed. Package `libsnappy-dev` on Debian, `snappy` on Arch.
 ```
 git clone https://github.com/LevitatingBusinessMan/snappy-cli.git
 cd snappy-cli


### PR DESCRIPTION
Make sure that the package `libsnappy-dev` (Debian) or `snappy` (Arch) is installed.